### PR TITLE
Updated compileSdkVersion & targetSdkVersion to 36.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,10 +29,10 @@ android {
         namespace 'in.jvapps.disable_battery_optimization'
     }
 
-    compileSdkVersion 31
+    compileSdkVersion 36
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 36
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
Updated compileSdkVersion & targetSdkVersion to 36 to solve below issue.. 
Dependency 'androidx.activity:activity:1.8.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :disable_battery_optimization is currently compiled against android-31.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).